### PR TITLE
Add job opportunities listing for students and small adjustments

### DIFF
--- a/client/html/pages/home.html
+++ b/client/html/pages/home.html
@@ -71,10 +71,10 @@
           <div id="homeCarousel" class="carousel slide" data-ride="carousel">
             <!-- Wrapper for slides -->
             <div class="carousel-inner" role="listbox">
-              <div class="item active"> <img src="img/home-bg1.jpg" alt=""> </div>
-              <div class="item"> <img src="img/home-bg2.jpg" alt=""> </div>
-              <div class="item"> <img src="img/home-bg3.jpg" alt=""> </div>
-              <div class="item"> <img src="img/home-bg4.jpg" alt=""> </div>
+              <div class="item active"> <img src="/img/home-bg1.jpg" alt=""> </div>
+              <div class="item"> <img src="/img/home-bg2.jpg" alt=""> </div>
+              <div class="item"> <img src="/img/home-bg3.jpg" alt=""> </div>
+              <div class="item"> <img src="/img/home-bg4.jpg" alt=""> </div>
             </div>
           </div>
         </div>

--- a/client/html/pages/panel/index.html
+++ b/client/html/pages/panel/index.html
@@ -44,42 +44,42 @@
             </div>
             <ul class="timeline collapse-lg timeline-hairline">
 
-            {{#if isInRole 'student' 'default-group'}}
-              {{#each vacancy in vacancies}}
-                <li class="timeline-inverted">
-                  <div class="timeline-circ circ-xl style-primary">
-                    <i class="md mdi mdi-calendar-check"></i>
-                  </div>
-                  <div class="timeline-entry">
-                    <div class="card style-default-light">
-                      <div class="card-body small-padding">
-                        <span class="text-medium">
-                          <span class="text-primary">{{vacancy.companyName}}</span> cadastrou uma 
-                            <a class="text-primary" href="#">vaga</a> para {{vacancy.nome}}.
-                          </span>
-                          <br>
-                        <span class="opacity-50">{{vacancy.createdAt}}</span>
+              {{#if isInRole 'student' 'default-group'}}
+                {{#if vacancies}}
+                  {{#each vacancy in vacancies}}
+                    <li class="timeline-inverted">
+                      <div class="timeline-circ circ-xl style-primary">
+                        <i class="md mdi mdi-calendar-check"></i>
+                      </div>
+                      <div class="timeline-entry">
+                        <div class="card style-default-light">
+                          <div class="card-body small-padding">
+                            <span class="text-medium">
+                              <span class="text-primary">{{vacancy.companyName}}</span> cadastrou uma 
+                                <a class="text-primary" href="#">vaga</a> para {{vacancy.nome}}.
+                              </span>
+                              <br>
+                            <span class="opacity-50">{{vacancy.createdAt}}</span>
+                          </div>
+                        </div>
+                      </div>
+                    </li>
+                  {{/each}}
+                {{else}}
+                  <li class="timeline-inverted">
+                    <div class="timeline-circ circ-xl style-primary">
+                      <i class="md mdi mdi-calendar-check"></i>
+                    </div>
+                    <div class="timeline-entry">
+                      <div class="card style-default-light">
+                        <div class="card-body small-padding">
+                          <p>Ops, ainda não há nenhuma atividade registrada :(</p>
+                        </div>
                       </div>
                     </div>
-                  </div>
-                </li>
-              {{/each}}
-
-              {{else}}
-
-              <li class="timeline-inverted">
-                <div class="timeline-circ circ-xl style-primary">
-                  <i class="md mdi mdi-calendar-check"></i>
-                </div>
-                <div class="timeline-entry">
-                  <div class="card style-default-light">
-                    <div class="card-body small-padding">
-                      <p>Ops, ainda não há nenhuma atividade registrada :(</p>
-                    </div>
-                  </div>
-                </div>
-              </li>
-              {{/if}} 
+                  </li>
+                {{/if}}
+              {{/if}}
 
             </ul>
           </div>

--- a/client/html/pages/panel/index.html
+++ b/client/html/pages/panel/index.html
@@ -34,7 +34,7 @@
                 {{#if isInRole 'company' 'default-group'}}
                   <p>Abaixo, confira as últimas vagas registradas pela sua empresa:</p>
                   <div class="pull-right">
-                    <a href="{{pathForNewVacancy}}" class="btn ink-reaction btn-floating-action btn-primary">
+                    <a href="{{pathForNewJob}}" class="btn ink-reaction btn-floating-action btn-primary">
                       <i class="md mdi mdi-plus"></i>
                     </a>
                   </div>
@@ -45,8 +45,8 @@
             <ul class="timeline collapse-lg timeline-hairline">
 
               {{#if isInRole 'student' 'default-group'}}
-                {{#if vacancies}}
-                  {{#each vacancy in vacancies}}
+                {{#if jobs}}
+                  {{#each vacancy in jobs}}
                     <li class="timeline-inverted">
                       <div class="timeline-circ circ-xl style-primary">
                         <i class="md mdi mdi-calendar-check"></i>

--- a/client/html/pages/panel/index.html
+++ b/client/html/pages/panel/index.html
@@ -46,7 +46,7 @@
 
               {{#if isInRole 'student' 'default-group'}}
                 {{#if jobs}}
-                  {{#each vacancy in jobs}}
+                  {{#each jobs}}
                     <li class="timeline-inverted">
                       <div class="timeline-circ circ-xl style-primary">
                         <i class="md mdi mdi-calendar-check"></i>
@@ -55,11 +55,11 @@
                         <div class="card style-default-light">
                           <div class="card-body small-padding">
                             <span class="text-medium">
-                              <span class="text-primary">{{vacancy.companyName}}</span> cadastrou uma 
-                                <a class="text-primary" href="#">vaga</a> para {{vacancy.nome}}.
+                              <span class="text-primary">{{companyName}}</span> cadastrou uma 
+                                <a class="text-primary" href="#">vaga</a> para {{nome}}.
                               </span>
                               <br>
-                            <span class="opacity-50">{{vacancy.createdAt}}</span>
+                            <span class="opacity-50">{{createdAt}}</span>
                           </div>
                         </div>
                       </div>

--- a/client/html/pages/panel/jobs/index.html
+++ b/client/html/pages/panel/jobs/index.html
@@ -7,7 +7,6 @@
     </div>
     <div class="section-body contain-lg">
       <div class="card tabs-left style-default-light">
-        <!-- BEGIN SEARCH BAR -->
         <div class="card-body style-primary no-y-padding">
           <form class="form form-inverse">
             <div class="form-group">
@@ -21,25 +20,18 @@
                 </div>
               </div>
             </div>
-            <!--end .form-group -->
           </form>
         </div>
-        <!--end .card-body -->
-        <!-- END SEARCH BAR -->
-        <!-- BEGIN TAB RESULTS -->
-        <!--ul class="card-head nav nav-tabs tabs-accent" data-toggle="tabs">
-								<li class="active"><a href="#web1">Web</a></li>
-							</ul-->
-        <!-- END TAB RESULTS -->
-        <!-- BEGIN TAB CONTENT -->
         <div class="card-body tab-content style-default-bright">
           <div class="tab-pane active" id="web1">
             <div class="row">
               <div class="col-lg-12">
-                <!-- BEGIN PAGE HEADER -->
-                <div class="margin-bottom-xxl"> <span class="text-light text-lg">Foram encontradas <strong>2</strong> vagas</span>
+                <div class="margin-bottom-xxl">
+                  <span class="text-light text-lg">Foram encontradas <strong>{{jobs.length}}</strong> vagas</span>
                   <div class="btn-group btn-group-sm pull-right">
-                    <button type="button" class="btn btn-default-light dropdown-toggle" data-toggle="dropdown"> <span class="glyphicon glyphicon-arrow-down"></span> Filtrar por </button>
+                    <button type="button" class="btn btn-default-light dropdown-toggle" data-toggle="dropdown">
+                      <span class="glyphicon glyphicon-arrow-down"></span> Filtrar por
+                    </button>
                     <ul class="dropdown-menu dropdown-menu-left animation-dock" role="menu">
                       <li class="active">
                         <div class="checkbox checkbox-styled">
@@ -104,59 +96,38 @@
                     </ul>
                   </div>
                   <div class="btn-group btn-group-sm pull-right">
-                    <button type="button" class="btn btn-default-light dropdown-toggle" data-toggle="dropdown"> <span class="glyphicon glyphicon-arrow-down"></span> Ordenar por </button>
+                    <button type="button" class="btn btn-default-light dropdown-toggle" data-toggle="dropdown">
+                      <span class="glyphicon glyphicon-arrow-down"></span> Ordenar por
+                    </button>
                     <ul class="dropdown-menu dropdown-menu-right animation-dock" role="menu">
                       <li class="active"><a href="#">Data</a></li>
                       <li><a href="#">Nome</a></li>
                     </ul>
                   </div>
                 </div>
-                <!--end .margin-bottom-xxl -->
-                <!-- END PAGE HEADER -->
-                <!-- BEGIN RESULT LIST -->
                 <div class="list-results list-results-underlined">
-                  <div class="col-xs-12">
-                    <p> <a class="text-medium text-lg text-primary" href="#">Desenvolvedor Web Front-End</a>
-                      <br/> <a class="opacity-75" href="#">http://www.ibm.com/br-pt/</a> </p>
-                    <div class="contain-xs pull-left"> Estamos à procura de um profissional que possa atender aos seguintes requisitos: - Estar cursando os cursos de (...) </div>
-                  </div>
-                  <!--end .col -->
-                  <div class="col-xs-12">
-                    <p> <a class="text-medium text-lg text-primary" href="#">Material Design Search</a>
-                      <br/> <a class="opacity-75" href="#">http://www.codecovers.eu/search/help</a> </p>
-                    <div class="contain-xs pull-left"> You should have around 60 characters per line if you want a good reading experience. Having the right amount of characters on each line is key to the readability of your text. </div>
-                  </div>
-                  <div class="col-xs-12">
-                    <p>Ops... Parece que não encontramos o que está procurando :(</p>
-                  </div>
-                  <!--end .col -->
+                  {{#if jobs}}
+                    {{#each jobs}}
+                      <div class="col-xs-12">
+                        <p>
+                          <a class="text-medium text-lg text-primary" href="#">{{nome}}</a>
+                          <br/>
+                          <strong>{{companyName}}</strong>
+                        </p>
+                        <div class="contain-lg">{{descricao}}</div>
+                      </div>
+                    {{/each}}
+                  {{else}}
+                    <div class="col-xs-12">
+                      <p>Ops... Parece que não encontramos o que está procurando :(</p>
+                    </div>
+                  {{/if}}
                 </div>
-                <!--end .list-results -->
-                <!-- END RESULTS LIST -->
-                <!-- BEGIN PAGING -->
-                <!-- TODO: Do we need a pagination? Or will we display everything in a single page? -->
-                <!--ul class="pagination">
-												<li class="disabled"><a href="#">«</a></li>
-												<li class="active"><a href="#">1 <span class="sr-only">(current)</span></a></li>
-												<li><a href="#">2</a></li>
-												<li><a href="#">3</a></li>
-												<li><a href="#">4</a></li>
-												<li><a href="#">5</a></li>
-												<li><a href="#">»</a></li>
-											</ul-->
-                <!-- END PAGING -->
               </div>
-              <!--end .col -->
             </div>
-            <!--end .row -->
           </div>
-          <!--end .tab-pane -->
         </div>
-        <!--end .card-body -->
-        <!-- END TAB CONTENT -->
       </div>
-      <!--end .card -->
     </div>
-    <!--end .section-body -->
   </section>
 </template>

--- a/client/html/pages/panel/jobs/index.html
+++ b/client/html/pages/panel/jobs/index.html
@@ -1,4 +1,4 @@
-<template name="jobSearch">
+<template name="jobs">
   <section>
     <div class="section-header">
       <ol class="breadcrumb">

--- a/client/html/pages/panel/jobs/new.html
+++ b/client/html/pages/panel/jobs/new.html
@@ -1,4 +1,4 @@
-<template name="newVacancy">
+<template name="newJob">
   <section class="hasPaddingTop">
     <div class="section-body no-margin">
       <form class="form">

--- a/client/html/parts/menubar.html
+++ b/client/html/parts/menubar.html
@@ -39,7 +39,7 @@
               
             </li>
             <li>
-              <a href="{{pathForVacancySearch}}">
+              <a href="{{pathForJobSearch}}">
                 <div class="gui-icon">
                   <i class="md mdi mdi-magnify"></i>
                 </div> <span class="title">Vagas</span>

--- a/client/html/parts/menubar.html
+++ b/client/html/parts/menubar.html
@@ -39,7 +39,7 @@
               
             </li>
             <li>
-              <a href="{{pathForJobSearch}}">
+              <a href="{{pathForJob}}">
                 <div class="gui-icon">
                   <i class="md mdi mdi-magnify"></i>
                 </div> <span class="title">Vagas</span>

--- a/imports/api/collections/jobs.js
+++ b/imports/api/collections/jobs.js
@@ -1,13 +1,13 @@
-Vacancies = new Mongo.Collection("vacancies");
+Jobs = new Mongo.Collection("jobs");
 
 //is not working
-Vacancies.allow({
+Jobs.allow({
   insert: function(userId, doc) {
     return Roles.userIsInRole(Meteor.userId(), 'company', 'default-group');
   }
 });
 
-Vacancy = new SimpleSchema({
+Job = new SimpleSchema({
   categoria: {
     type: String,
     label: "Categoria"
@@ -57,4 +57,4 @@ Vacancy = new SimpleSchema({
   }
 });
 
-Vacancies.attachSchema(Vacancy);
+Jobs.attachSchema(Job);

--- a/imports/api/methods.js
+++ b/imports/api/methods.js
@@ -1,6 +1,6 @@
 import './collections/password.js';
 import './collections/email.js';
-import '/imports/api/collections/vacancies.js';
+import '/imports/api/collections/jobs.js';
 
 Meteor.methods({
   saveUser: function (data, type) {
@@ -14,7 +14,7 @@ Meteor.methods({
 
     return true;
   },
-  saveVacancy: function (vacancy) {
-    Vacancies.insert(vacancy);
+  saveJob: function (vacancy) {
+    Jobs.insert(vacancy);
   }
 });

--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -11,7 +11,7 @@ import './materialadmin-load.js';
 import '/imports/ui/layouts/layout.js';
 import '/imports/ui/pages/home.js';
 import '/imports/ui/pages/panel/index.js';
-import '/imports/ui/pages/panel/add-vacancy.js';
+import '/imports/ui/pages/panel/jobs/new.js';
 import '/imports/ui/pages/signup/students.js';
 import '/imports/ui/pages/signup/companies.js';
 import '/imports/ui/parts/header.js';

--- a/imports/startup/client/index.js
+++ b/imports/startup/client/index.js
@@ -11,6 +11,7 @@ import './materialadmin-load.js';
 import '/imports/ui/layouts/layout.js';
 import '/imports/ui/pages/home.js';
 import '/imports/ui/pages/panel/index.js';
+import '/imports/ui/pages/panel/jobs/index.js';
 import '/imports/ui/pages/panel/jobs/new.js';
 import '/imports/ui/pages/signup/students.js';
 import '/imports/ui/pages/signup/companies.js';

--- a/imports/ui/components/forms.js
+++ b/imports/ui/components/forms.js
@@ -2,15 +2,15 @@ import {
   Template
 } from 'meteor/templating';
 
-Template.PanelLayout.onRendered(function() {
-  setMasks();
-  setCalendar();
-});
+FlowRouter.triggers.enter([init]);
 
-Template.HomeLayout.onRendered(function() {
-  setMasks();
-  setCalendar();
-});
+function init() {
+// WE SHOULD FIND A BETTER SOLUTION FOR THIS, TIMEOUT IS NOT A GOOD IDEA
+ Meteor.setTimeout(function() {
+    setMasks();
+    setCalendar();
+ }, 500);
+}
 
 function setMasks() {
   $('.phone-number').inputmask("(99) 99999999[9]", {

--- a/imports/ui/pages/panel/index.js
+++ b/imports/ui/pages/panel/index.js
@@ -1,6 +1,6 @@
 Template.mainPanel.helpers({
-  pathForNewVacancy: function() {
-    return FlowRouter.path("newVacancy");
+  pathForNewJob: function() {
+    return FlowRouter.path("newJob");
   },
   pathForStudentProfile: function() {
     return FlowRouter.path("studentProfile");
@@ -8,8 +8,8 @@ Template.mainPanel.helpers({
   pathForCompanyProfile: function() {
     return FlowRouter.path("companyProfile");
   },
-  vacancies: function() {
-    return Vacancies.find().fetch();
+  jobs: function() {
+    return Jobs.find().fetch();
   }
 });
 

--- a/imports/ui/pages/panel/jobs/index.js
+++ b/imports/ui/pages/panel/jobs/index.js
@@ -1,0 +1,5 @@
+Template.jobs.helpers({
+  jobs: function() {
+    return Jobs.find().fetch();
+  }
+});

--- a/imports/ui/pages/panel/jobs/new.js
+++ b/imports/ui/pages/panel/jobs/new.js
@@ -1,16 +1,16 @@
 import {
   Template
 } from 'meteor/templating';
-import '/client/html/pages/panel/add-vacancy.html';
-import '/imports/api/collections/vacancies.js';
+import '/client/html/pages/panel/jobs/new.html';
+import '/imports/api/collections/jobs.js';
 
 var json = require('/imports/ui/components/skills.json');
 
-Template.newVacancy.onCreated(function() {
+Template.newJob.onCreated(function() {
   this.skills = new ReactiveVar(json);
 });
 
-Template.newVacancy.onRendered(function() { 
+Template.newJob.onRendered(function() { 
   $("#tags").chosen({
     no_results_text: "Sem resultados para",
     placeholder_text_single: "Selecione uma opção",
@@ -18,7 +18,7 @@ Template.newVacancy.onRendered(function() {
   });
 });
 
-Template.newVacancy.events({
+Template.newJob.events({
   "submit form": function(event) {
     event.preventDefault();
     //REMOVE ERRORS
@@ -35,7 +35,7 @@ Template.newVacancy.events({
       tags: $('#tags').val()
     }
 
-    Meteor.call('saveVacancy', vacancy, function(error) {
+    Meteor.call('saveJob', vacancy, function(error) {
       if (error) {
         Meteor.call('displayErrors', error);
       }
@@ -57,7 +57,7 @@ function resetForm() {
   $('select').trigger('chosen:updated');
 }
 
-Template.newVacancy.helpers({
+Template.newJob.helpers({
   skills: function() {
     return Template.instance().skills.get();
   }

--- a/imports/ui/parts/menubar.js
+++ b/imports/ui/parts/menubar.js
@@ -5,12 +5,12 @@ Template.menubar.helpers({
   pathForStudentPanel: function() {
     return FlowRouter.path("student");
   },
-  pathForVacancySearch: function() {
+  pathForJobSearch: function() {
     if(Roles.userIsInRole(Meteor.userId(), 'student', 'default-group')){
-      return FlowRouter.path("studentJobSearch");
+      return FlowRouter.path("studentjobs");
     }
     else if(Roles.userIsInRole(Meteor.userId(), 'company', 'default-group')){
-      return FlowRouter.path("companyJobSearch");
+      return FlowRouter.path("companyjobs");
     }
   }
 });

--- a/imports/ui/parts/menubar.js
+++ b/imports/ui/parts/menubar.js
@@ -5,7 +5,7 @@ Template.menubar.helpers({
   pathForStudentPanel: function() {
     return FlowRouter.path("student");
   },
-  pathForJobSearch: function() {
+  pathForJob: function() {
     if(Roles.userIsInRole(Meteor.userId(), 'student', 'default-group')){
       return FlowRouter.path("studentjobs");
     }

--- a/lib/router.js
+++ b/lib/router.js
@@ -40,7 +40,7 @@ FlowRouter.route('/cadastro/empresa', {
 var panel = FlowRouter.group({
   triggersEnter: [
     function(context, redirect) {
-      Meteor.subscribe('vacancies');
+      Meteor.subscribe('jobs');
     },
     function(context, redirect, stop) {
       Tracker.autorun(function() {
@@ -85,16 +85,16 @@ company.route('/perfil', {
 });
 
 company.route('/vagas/nova', {
-  name: 'newVacancy',
+  name: 'newJob',
   action: function(params) {
-    BlazeLayout.render('PanelLayout', { header: "header", menubar: "menubar", main: "newVacancy" });
+    BlazeLayout.render('PanelLayout', { header: "header", menubar: "menubar", main: "newJob" });
   }
 });
 
 company.route('/vagas', {
-  name: 'companyJobSearch',
+  name: 'companyjobs',
   action: function(params) {
-    BlazeLayout.render('PanelLayout', { header: "header", menubar: "menubar", main: "jobSearch" });
+    BlazeLayout.render('PanelLayout', { header: "header", menubar: "menubar", main: "jobs" });
   }
 });
 
@@ -129,9 +129,9 @@ student.route('/perfil', {
 });
 
 student.route('/vagas', {
-  name: 'studentJobSearch',
+  name: 'studentjobs',
   action: function(params) {
-    BlazeLayout.render('PanelLayout', { header: "header", menubar: "menubar", main: "jobSearch" });
+    BlazeLayout.render('PanelLayout', { header: "header", menubar: "menubar", main: "jobs" });
   }
 });
 

--- a/server/publish.js
+++ b/server/publish.js
@@ -1,6 +1,6 @@
-import '/imports/api/collections/vacancies.js';
+import '/imports/api/collections/jobs.js';
 
-Meteor.publish('vacancies', function() {
-  // ONLY PUBLISHES VACANCIES TO LOGGED IN USERS
-  if (this.userId) return Vacancies.find();
+Meteor.publish('jobs', function() {
+  // ONLY PUBLISHES JOBS TO LOGGED IN USERS
+  if (this.userId) return Jobs.find();
 });


### PR DESCRIPTION
- Fix carousel images broken on firefox, and closes #26 
- Add else statement to main panel vacancies listing
- Add temporary fix to JSs breaking on signup forms
- Change all 'vacancies' occurrences to 'jobs' to standardize it
- Fix folder and files organization structure on panel
- Add jobs listing for students under "estudante/vagas":

![vacacies-listing](https://cloud.githubusercontent.com/assets/4267241/18561685/46c91516-7b57-11e6-8385-be27f61afe69.png)
