### PR TITLE
Fix user schema issue on signup

### DIFF
--- a/imports/api/collections/companies.js
+++ b/imports/api/collections/companies.js
@@ -1,8 +1,7 @@
 import './password.js';
 import './email.js';
 
-Schema = {};
-Schema.UserProfile = new SimpleSchema({
+Profile = new SimpleSchema({
   nome: {
     type: String,
     label: "Nome",
@@ -110,7 +109,7 @@ Schema.UserProfile = new SimpleSchema({
   },
 });
 
-Schema.User = new SimpleSchema({
+Company = new SimpleSchema({
   username: {
     type: String,
     optional: true
@@ -132,7 +131,7 @@ Schema.User = new SimpleSchema({
     type: Date
   },
   profile: {
-    type: Schema.UserProfile,
+    type: Profile,
     label: "Perfil",
     optional: false
   },
@@ -151,5 +150,3 @@ Schema.User = new SimpleSchema({
     optional: true
   }
 });
-
-Meteor.users.attachSchema(Schema.User);

--- a/imports/api/collections/students.js
+++ b/imports/api/collections/students.js
@@ -241,9 +241,7 @@ StudentsSchema5 = new SimpleSchema({
   }
 });
 
-Schemas = {};
-
-Schemas.UserProfile = new SimpleSchema({
+Profile = new SimpleSchema({
   formacao: {
     type: StudentsSchema2,
     label: "Formação",
@@ -266,9 +264,9 @@ Schemas.UserProfile = new SimpleSchema({
   }
 });
 
-Schemas.UserProfile._schema = _.extend(Schemas.UserProfile._schema, StudentsSchema1._schema);
+Profile._schema = _.extend(Profile._schema, StudentsSchema1._schema);
 
-Schemas.User = new SimpleSchema({
+Student = new SimpleSchema({
   username: {
     type: String,
     optional: true
@@ -290,7 +288,7 @@ Schemas.User = new SimpleSchema({
     type: Date
   },
   profile: {
-    type: Schemas.UserProfile,
+    type: Profile,
     label: "Perfil",
     optional: false
   },
@@ -309,5 +307,3 @@ Schemas.User = new SimpleSchema({
     optional: true
   }
 });
-
-Meteor.users.attachSchema(Schemas.User);

--- a/imports/api/methods.js
+++ b/imports/api/methods.js
@@ -1,17 +1,20 @@
 import './collections/password.js';
 import './collections/email.js';
 import '/imports/api/collections/jobs.js';
+import '/imports/api/collections/companies.js';
+import '/imports/api/collections/students.js';
 
 Meteor.methods({
-  saveUser: function (data, type) {
-    if (type == "student") {
-      require('/imports/api/collections/students.js');
-    } else {
-      require('/imports/api/collections/companies.js');
-    }
+  saveCompany: function (data) {
+    Meteor.users.attachSchema(Company);
     id = Accounts.createUser(data);
-    Roles.addUsersToRoles(id, type, 'user-type');
-
+    Roles.addUsersToRoles(id, 'company', 'user-type');
+    return true;
+  },
+  saveStudent: function (data) {
+    Meteor.users.attachSchema(Student);
+    id = Accounts.createUser(data);
+    Roles.addUsersToRoles(id, 'student', 'user-type');
     return true;
   },
   saveJob: function (vacancy) {

--- a/imports/ui/pages/signup/companies.js
+++ b/imports/ui/pages/signup/companies.js
@@ -32,7 +32,7 @@ Template.companySignup.events({
       }
     }
 
-    Meteor.call('saveUser', user, "company", function(error, result) {
+    Meteor.call('saveCompany', user, function(error, result) {
       if (error) {
         Meteor.call('displayErrors', error);
       } else if (result) {

--- a/imports/ui/pages/signup/students.js
+++ b/imports/ui/pages/signup/students.js
@@ -104,7 +104,7 @@ Template.studentSignup.events({
       }
     }
 
-    Meteor.call('saveUser', user, "student", function(error, result) {
+    Meteor.call('saveStudent', user, function(error, result) {
       if (error) {
         Meteor.call('displayErrors', error);
       } else if (result) {


### PR DESCRIPTION
The signup form was sometimes asking CNPJ for student and CPF for company, it was an issue related to the manner we were attaching the schema to the user.

We have two schemas for users: for **company** and **student**. Were attaching the schema to the user [here](https://github.com/BancoTalentosTCC/BancoTalentosTCC/pull/76/files#diff-f1a6b3c090d012f8443c00b1aafe1af3L155) and [here](https://github.com/BancoTalentosTCC/BancoTalentosTCC/pull/76/files#diff-f28693a485be35153f328002c5ad1db9L313), but it was causing problems because when we were saving the user it didn't know which one of them should use.

Now we have two methods to save, one for student (saveStudent) ad one for company (saveCompany), and we attach the schemas inside these functions to make sure we use the right schema, as you can see [here](https://github.com/BancoTalentosTCC/BancoTalentosTCC/pull/76/files#diff-a6f1b0c9a9d6a51faa546e15568c3ed0R9) for company and [here](https://github.com/BancoTalentosTCC/BancoTalentosTCC/pull/76/files#diff-a6f1b0c9a9d6a51faa546e15568c3ed0R15) for student.
